### PR TITLE
Update R workflow to include lintr and spelling checks  ( #10)

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -1,0 +1,53 @@
+name: R
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        r-version: ['3.6.3', '4.1.1']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up R ${{ matrix.r-version }}
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.r-version }}
+
+      - name: Install dependencies
+        run: |
+          install.packages(c("remotes", "rcmdcheck", "lintr", "spelling", "testthat"))
+          remotes::install_deps(dependencies = TRUE)
+        shell: Rscript {0}
+
+      - name: Run lintr
+        run: |
+          lintr::lint_package()
+        shell: Rscript {0}
+
+      - name: Check spelling
+        run: |
+          # This will check spelling in man/ files
+          if (requireNamespace("spelling", quietly = TRUE)) {
+            spelling::spell_check_package()
+          }
+        shell: Rscript {0}
+
+      - name: Run tests
+        run: |
+          testthat::test_dir("tests/testthat")
+        shell: Rscript {0}
+
+      - name: R CMD check
+        run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "error")
+        shell: Rscript {0}


### PR DESCRIPTION
Added additional R packages for linting, spelling and testing.

## Issue

Closes #10

## Description
This pull request introduces a new GitHub Actions workflow to automate R package checks on every push and pull request to the `main` branch. The workflow sets up an R environment, installs dependencies, runs linting, checks spelling, executes tests, and performs a package check for two R versions.

**Continuous Integration for R Packages:**

* Added `.github/workflows/r.yml` to run CI checks for R packages on `main` branch pushes and pull requests, including:
  * Setting up R environments for versions `3.6.3` and `4.1.1`
  * Installing dependencies and development tools
  * Running `lintr` for code linting
  * Checking documentation spelling with `spelling`
  * Running unit tests with `testthat`
  * Executing `rcmdcheck` for package validation

## Contributor checklist
- [ ] Code passes lintr check (`lintr::lint_dir()`)
- [ ] Code passes all unit tests (`devtools::test()`)
- [ ] New logic covered by unit tests (`devtools::test_coverage()`)
- [ ] New logic is documented (`devtools::check_man()`)

